### PR TITLE
Fixed disconnection due to serviceWorker termination

### DIFF
--- a/src/background/application.ts
+++ b/src/background/application.ts
@@ -75,6 +75,20 @@ function connect(tabId: number): void {
   }
 }
 
+function keepAlive() {
+  const keepAliveIntervalId = setInterval(
+    () => {
+      if (ws) {
+        ws.send('keepalive');
+      } else {
+        clearInterval(keepAliveIntervalId);
+      }
+    },
+    // Set the interval to 20 seconds to prevent the service worker from becoming inactive.
+    20 * 1000 
+  );
+}
+
 function send(action: ApplicationMessageAction, payload: any = {}): void {
   ws.send(JSON.stringify({ action, payload }));
 }
@@ -85,6 +99,7 @@ async function handleMessage(message: ExtensionMessage | any, sender: Runtime.Me
   switch (message.action) {
     case ExtensionMessageAction.ConnectApp:
       connect(sender.tab.id);
+      keepAlive();
       break;
     case ExtensionMessageAction.DisconnectApp:
       if (connectedTabId === sender.tab.id) {


### PR DESCRIPTION
With manifest v3, the serviceWorkers are much more aggressively terminated. Writing to the WebSocket before the 30s timeout will keep the serviceWorker alive and avoid disconnection with the host app.